### PR TITLE
Base64 encoded images inline in markdown cause build errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,12 @@ function clean(path, templatePath = ".") {
       // Fixes HTML/JSX tags by transforming HTML into markdown or adding closing tags as needed.
       unified()
         .use(parse)
-        .use(markdownCleaner, cleaningOptions.cleanHtmlNodes, optionalTags)
+        .use(
+          markdownCleaner,
+          cleaningOptions.cleanHtmlNodes,
+          optionalTags,
+          file.name
+        )
         .use(stringify, {
           incrementListMarker: false,
         })

--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
   "dependencies": {
     "@svgr/core": "^5.5.0",
     "html-tags": "^3.1.0",
+    "mime-types": "^2.1.29",
+    "parse-data-url": "^3.0.0",
     "remark-frontmatter": "^3.0.0",
     "remark-parse": "^9.0.0",
     "remark-stringify": "^9.0.1",
     "shelljs": "^0.8.4",
     "to-vfile": "^6.1.0",
-    "unified": "^9.2.0"
+    "unified": "^9.2.0",
+    "uuid": "^8.3.2"
   }
 }

--- a/src/extractBase64Images.js
+++ b/src/extractBase64Images.js
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const parseDataUrl = require("parse-data-url");
+const mime = require("mime-types");
+const { v4: uuidv4 } = require("uuid");
+
+function extractBase64Images(nodeValue, filePath) {
+  const parsed = parseDataUrl(nodeValue);
+  const extension = mime.extension(parsed.contentType);
+  const basename = path.dirname(filePath);
+  const filename = `${uuidv4()}.${extension}`;
+
+  fs.writeFileSync(`${basename}/${filename}`, parsed.toBuffer());
+
+  return `./${filename}`;
+}
+
+module.exports = extractBase64Images;

--- a/src/markdownCleaner.js
+++ b/src/markdownCleaner.js
@@ -12,10 +12,11 @@
 
 const addLineBreaks = require("./addLineBreaks");
 const cleanHtmlNodes = require("./cleanHtmlNodes");
+const extractBase64Images = require("./extractBase64Images");
 
 module.exports = markdownCleaner;
 
-function markdownCleaner(cleaningOption, pluginOptionTags = []) {
+function markdownCleaner(cleaningOption, pluginOptionTags = [], filePath) {
   return cleanMarkdown;
   function cleanMarkdown(node) {
     const type = node && node.type;
@@ -30,6 +31,14 @@ function markdownCleaner(cleaningOption, pluginOptionTags = []) {
         node.value = nodeValue;
       } catch (e) {
         throw Error(`${e.message}`);
+      }
+    } else if (type === `image`) {
+      if (cleaningOption === "cleanHtmlNodes" && node.url.startsWith("data:")) {
+        try {
+          node.url = extractBase64Images(node.url, filePath);
+        } catch (e) {
+          throw Error(`${e.message}`);
+        }
       }
     } else if (type !== "code" && type !== "inlineCode") {
       // if the node is not html convert < and > to &lt; and &gt;

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,6 +659,18 @@ micromark@~2.11.0:
     debug "^4.0.0"
     parse-entities "^2.0.0"
 
+mime-db@1.46.0:
+  version "1.46.0"
+  resolved "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-adobe-release/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
+  integrity sha1-Ymd0in95lZTePLyM3pHe80lmHO4=
+
+mime-types@^2.1.29:
+  version "2.1.29"
+  resolved "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-adobe-release/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2"
+  integrity sha1-HUq3faZLkfX3JInfKSNlY3VLsbI=
+  dependencies:
+    mime-db "1.46.0"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-adobe-release/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -694,6 +706,13 @@ parent-module@^1.0.0:
   integrity sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=
   dependencies:
     callsites "^3.0.0"
+
+parse-data-url@^3.0.0:
+  version "3.0.0"
+  resolved "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-adobe-release/parse-data-url/-/parse-data-url-3.0.0.tgz#a7eae0a8a035e972b3f05bb23a06a9bc82b8616a"
+  integrity sha1-p+rgqKA16XKz8FuyOgapvIK4YWo=
+  dependencies:
+    valid-data-url "^3.0.1"
 
 parse-entities@^2.0.0:
   version "2.0.0"
@@ -851,6 +870,16 @@ unist-util-stringify-position@^2.0.0:
   integrity sha1-zOO/oc34W6c3XR1bF73Eytqb2do=
   dependencies:
     "@types/unist" "^2.0.2"
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-adobe-release/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=
+
+valid-data-url@^3.0.1:
+  version "3.0.1"
+  resolved "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-adobe-release/valid-data-url/-/valid-data-url-3.0.1.tgz#826c1744e71b5632e847dd15dbd45b9fb38aa34f"
+  integrity sha1-gmwXROcbVjLoR90V29Rbn7OKo08=
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Converts inline base64 images into binary images

## Related Issue

DEVEP-2598

## Motivation and Context

Fixes potential build errors and allows our build system to resize the image properly

## How Has This Been Tested?

gatsby develop/build/serve

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
