### PR TITLE
🎉  DEVEP-2638: Support Jekyll links

### DIFF
--- a/src/jekyllLinks.js
+++ b/src/jekyllLinks.js
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const url = require("url");
+
+function jekyllLinks(nodeValue, filePath) {
+  const link = url.parse(nodeValue);
+  // if we have a relative link check to see if it is Jekyll style
+  if (!link.protocol && link?.pathname?.endsWith(".html")) {
+    const originalBaseName = path.dirname(filePath);
+    const basename = path.dirname(link.pathname);
+    const filename = path.basename(link.pathname, ".html");
+    const mdfilename = path.join(originalBaseName, basename, `${filename}.md`);
+
+    if (fs.existsSync(mdfilename)) {
+      return path.join(
+        basename,
+        `${filename}.md${link.hash ? link.hash : ""}${
+          link.search ? link.search : ""
+        }`
+      );
+    } else {
+      return nodeValue;
+    }
+  } else {
+    return nodeValue;
+  }
+}
+
+module.exports = jekyllLinks;

--- a/src/markdownCleaner.js
+++ b/src/markdownCleaner.js
@@ -13,6 +13,7 @@
 const addLineBreaks = require("./addLineBreaks");
 const cleanHtmlNodes = require("./cleanHtmlNodes");
 const extractBase64Images = require("./extractBase64Images");
+const jekyllLinks = require("./jekyllLinks");
 
 module.exports = markdownCleaner;
 
@@ -39,6 +40,12 @@ function markdownCleaner(cleaningOption, pluginOptionTags = [], filePath) {
         } catch (e) {
           throw Error(`${e.message}`);
         }
+      }
+    } else if (type === `link` && cleaningOption === "cleanHtmlNodes") {
+      try {
+        node.url = jekyllLinks(node.url, filePath);
+      } catch (e) {
+        throw Error(`${e.message}`);
       }
     } else if (type !== "code" && type !== "inlineCode") {
       // if the node is not html convert < and > to &lt; and &gt;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Supports Jekyll style lines in markdown

## Related Issue

DEVEP-2638

## Motivation and Context

Jekyll converts pages from foo.md to foo.html. So if you are doing internal linking in md files you will use .html for the end of your file name so it works in production. We always keep our file paths as .md so this re-writes the links to work if the source repo is coming over from Jekyll

## How Has This Been Tested?

Local tests in markdown cleaner then gatsby develop/build/serve

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
