### PR TITLE
🐛  Leave open API link unchanged if file does not exist

### DIFF
--- a/src/__tests__/__fixtures__/linkOpenApiSpecs/linkopenapispecs.md
+++ b/src/__tests__/__fixtures__/linkOpenApiSpecs/linkopenapispecs.md
@@ -7,3 +7,5 @@
 [Swagger in sub folder](./subfolder/openapi.json)
 
 [Swagger in sub folder](/linkOpenApiSpecs/openapi.json)
+
+[Swagger file not in repo](api/notfound.yaml)

--- a/src/__tests__/index.tests.js
+++ b/src/__tests__/index.tests.js
@@ -98,6 +98,14 @@ describe("linkOpenApiSpecs", () => {
       `/src/__tests__/__fixtures__/linkOpenApiSpecs/subfolder/openapi.json`
     );
   });
+  it("OpenAPI spec file not in repo", () => {
+    const value = linkOpenApiSpecs(
+      "api/notfound.yaml",
+      `${cwd}/src/__tests__/__fixtures__/linkOpenApiSpecs/linkopenapispecs.md`,
+      `${cwd}`
+    );
+    expect(value).toBe(`api/notfound.yaml`);
+  });
 });
 
 describe("addLineBreaks", () => {

--- a/src/linkOpenApiSpecs.js
+++ b/src/linkOpenApiSpecs.js
@@ -29,16 +29,18 @@ function linkOpenApiSpecs(nodeValue, filePath, rootFolder) {
     const filename = path.basename(nodeValue);
     const testFilename = path.join(originalBaseName, basename, filename);
 
-    const data = fs.readFileSync(testFilename, {
-      encoding: "utf8",
-      flag: "r",
-    });
-    if (data.includes("swagger") || data.includes("openapi")) {
-      let returnValue =
-        testFilename.indexOf(rootFolder) === 0
-          ? testFilename.slice(rootFolder.length)
-          : testFilename;
-      return returnValue.startsWith("/") ? returnValue : `/${returnValue}`;
+    if (fs.existsSync(testFilename)) {
+      const data = fs.readFileSync(testFilename, {
+        encoding: "utf8",
+        flag: "r",
+      });
+      if (data.includes("swagger") || data.includes("openapi")) {
+        let returnValue =
+          testFilename.indexOf(rootFolder) === 0
+            ? testFilename.slice(rootFolder.length)
+            : testFilename;
+        return returnValue.startsWith("/") ? returnValue : `/${returnValue}`;
+      }
     }
   }
   return nodeValue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If we don't find the OpenAPI file at the path in the link we return the link unchanged instead of throwing an error.

## Related Issue

n/a

## Motivation and Context

Removes a giant stack trace from the build logs to make things more friendly for end users

## How Has This Been Tested?

- Added tests
- Ran it against a test repo with problem and then did a gatsby build/serve to test the repo works properly.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
